### PR TITLE
Support for toggles and equations

### DIFF
--- a/lib/notion_to_md/blocks.rb
+++ b/lib/notion_to_md/blocks.rb
@@ -14,6 +14,7 @@ module NotionToMd
       Types.method(:numbered_list_item).name,
       Types.method(:paragraph).name,
       Types.method(:to_do).name,
+      Types.method(:toggle).name,
       :table
     ].freeze
 

--- a/lib/notion_to_md/blocks/block.rb
+++ b/lib/notion_to_md/blocks/block.rb
@@ -32,8 +32,12 @@ module NotionToMd
       #
       def to_md(tab_width: 0)
         block_type = block.type.to_sym
-        md = Types.send(block_type, block[block_type])
-        md + build_nested_blocks(tab_width + 1)
+        if block_type == :toggle
+          Types.send(block_type, self)
+        else
+          md = Types.send(block_type, block[block_type])
+          md + build_nested_blocks(tab_width + 1)
+        end
       rescue NoMethodError
         Logger.info("Unsupported block type: #{block_type}")
         nil

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -108,18 +108,12 @@ module NotionToMd
         end
 
         def toggle(block)
-          result = []
-          result << "> [!CAUTION]"
-          result << "> **Unsupported Toggle Block**"
-          result << "> <br />"
-          result << "> Content needs to be imported manually."
-          result << "> <br />"
-          result << "> <br />"
-          result << "> This is the toggle title to help you find it in the original Notion page:"
-          result << "> <br />"
-          title = block[:rich_text].map {|text| Text.send(text[:type], text)}.join
-          result << "> **#{title}**"
-          result << "> <br />"
+          result = <<-TEXT
+            <details>
+              <summary>#{block.block.toggle["rich_text"].map { |text| Text.send(text[:type], text) }.join}</summary>
+              #{block.children.map(&:to_md).join}
+            </details>
+          TEXT
           result.join("\n")
         end
 

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -111,7 +111,7 @@ module NotionToMd
           result = <<-TEXT
             <details>
               <summary>#{block.block.toggle["rich_text"].map { |text| Text.send(text[:type], text) }.join}</summary>
-              #{block.children.map(&:to_md).join}
+              #{block.children.map(&:to_md).join("\n")}
             </details>
           TEXT
           result.strip

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -37,8 +37,7 @@ module NotionToMd
         end
 
         def numbered_list_item(block)
-          Logger.info('numbered_list_item type not supported. Shown as bulleted_list_item.')
-          bulleted_list_item(block)
+          "1. #{convert_text(block)}"
         end
 
         def to_do(block)
@@ -100,7 +99,7 @@ module NotionToMd
         end
 
         def blank
-          '<br />'
+          '\n\n'
         end
 
         def table_row(block)

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -114,7 +114,7 @@ module NotionToMd
               #{block.children.map(&:to_md).join}
             </details>
           TEXT
-          result.join("\n")
+          result.strip
         end
 
         def equation(block)

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -118,18 +118,9 @@ module NotionToMd
         end
 
         def equation(block)
-          result = []
-          result << "> [!CAUTION]"
-          result << "> **Unsupported Equation Block**"
-          result << "> <br />"
-          result << "> Content needs to be imported manually."
-          result << "> <br />"
-          result << "> <br />"
-          result << "> This is the equation to help you find it in the original Notion page:"
-          result << "> <br />"
-          result << "> **#{block[:expression]}**" # Returns ruby code with the equation at least
-          result << "> <br />"
-          result.join("\n")
+          # We use the Mathjax library in Kitt allowing us to use the following syntax https://www.mathjax.org/#gettingstarted
+          # e.g: https://github.com/lewagon/data-flashcards/blob/master/decks/03-Maths_01-Algebra-Calculus.yml#L13
+          "$#{block[:expression]}$"
         end
 
         def column_list(block)


### PR DESCRIPTION
This allows us to retrieve the content of a toggle and insert it in the markdown as a **details/summary** supported by Github
It allows also to insert equations with the syntax allowed by the [Mathjax](https://www.mathjax.org/) library in Kitt

![eWrVG7A1V3](https://github.com/lewagon/notion_to_md/assets/11377783/1118bfad-543e-477a-b87c-a718d42d21bf)


https://github.com/lewagon/data-analytics-challenges/blob/fc2b283d86714c0784707e04302110934079d9c7/02-Business-Analysis/01-GS-Finance/02-Finance-Greenweez/README.md