### PR TITLE
Change key methods

### DIFF
--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -236,8 +236,11 @@ module NotionToMd
         def add_link(text, content)
           href = text[:href]
           return content if href.nil?
-
-          "[#{content}](#{href})"
+          if content[-1] == " "
+            "[#{content.strip}](#{href}) "
+          else
+            "[#{content}](#{href})"
+          end
         end
 
         def add_annotations(text, content)

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+class String
+  def append_conditional_space
+    self[-1] == ' ' ? ' ' : ''
+  end
+end
 
 module NotionToMd
   module Blocks
@@ -237,7 +242,7 @@ module NotionToMd
           href = text[:href]
           return content if href.nil?
           
-          "[#{content.strip}](#{href})#{content[-1] == ' ' ? ' ' : ''}"
+          "[#{content.strip}](#{href})#{content.append_conditional_space}"
         end
 
         def add_annotations(text, content)

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -236,11 +236,8 @@ module NotionToMd
         def add_link(text, content)
           href = text[:href]
           return content if href.nil?
-          if content[-1] == " "
-            "[#{content.strip}](#{href}) "
-          else
-            "[#{content}](#{href})"
-          end
+          
+          "[#{content.strip}](#{href})#{content[-1] == ' ' ? ' ' : ''}"
         end
 
         def add_annotations(text, content)

--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -241,7 +241,7 @@ module NotionToMd
         def add_link(text, content)
           href = text[:href]
           return content if href.nil?
-          
+
           "[#{content.strip}](#{href})#{content.append_conditional_space}"
         end
 

--- a/lib/notion_to_md/text_annotation.rb
+++ b/lib/notion_to_md/text_annotation.rb
@@ -13,19 +13,11 @@ module NotionToMd
   class TextAnnotation
     class << self
       def italic(text)
-        if text[-1] == ' '
-          "_#{text.strip}_ "
-        else
-          "_#{text}_"
-        end
+        "_#{text.strip}_#{text[-1] == ' ' ? ' ' : ''}"
       end
 
       def bold(text)
-        if text[-1] == ' '
-          "**#{text.strip}** "
-        else
-          "**#{text}**"
-        end
+        "**#{text.strip}**#{text[-1] == ' ' ? ' ' : ''}"
       end
 
       def strikethrough(text)

--- a/lib/notion_to_md/text_annotation.rb
+++ b/lib/notion_to_md/text_annotation.rb
@@ -13,11 +13,11 @@ module NotionToMd
   class TextAnnotation
     class << self
       def italic(text)
-        "_#{text.strip}_#{text[-1] == ' ' ? ' ' : ''}"
+        "_#{text.strip}_#{text.append_conditional_space}"
       end
 
       def bold(text)
-        "**#{text.strip}**#{text[-1] == ' ' ? ' ' : ''}"
+        "**#{text.strip}**#{text.append_conditional_space}"
       end
 
       def strikethrough(text)

--- a/lib/notion_to_md/text_annotation.rb
+++ b/lib/notion_to_md/text_annotation.rb
@@ -13,11 +13,19 @@ module NotionToMd
   class TextAnnotation
     class << self
       def italic(text)
-        "*#{text}*"
+        if text[-1] == ' '
+          "_#{text.strip}_ "
+        else
+          "_#{text}_"
+        end
       end
 
       def bold(text)
-        "**#{text}**"
+        if text[-1] == ' '
+          "**#{text.strip}** "
+        else
+          "**#{text}**"
+        end
       end
 
       def strikethrough(text)


### PR DESCRIPTION
### Context 

Rich text accepts `space` characters as bold, italic, or as links, while the same doesn't apply to Markdown, breaking the formatting during the parsing.

We handle this in the methods that apply Italic and Bold to text, and the method that builds links. The logic is same for all: If the text has a space in the end, format the rest and add the space AFTER.

I have also improved the `italic` method by using `_` instead of `*` for the Italic. I believe it improves readability for us and helps us debug possible issues in the future.

You can the result of the new parsing logic here: https://github.com/lewagon/data-analytics-challenges/blob/8cdf05f60d8b17fa11e368c97b8ff1a2182c697e/01-Setup/01-Intro-and-Setup/01-Setup/README.md