### PR TITLE
Call blank method instead of ---

### DIFF
--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -100,7 +100,7 @@ module NotionToMd
         end
 
         def divider(_block)
-          '---'
+          blank
         end
 
         def blank


### PR DESCRIPTION
### Context

Since the divider are all being removed from the markdown,  I suggest we simply call the already defined `#blank` method whenever we try to parse a `divider` block.