### PR TITLE
Support pages with pagination

### DIFF
--- a/lib/notion_to_md/blocks.rb
+++ b/lib/notion_to_md/blocks.rb
@@ -39,6 +39,17 @@ module NotionToMd
     #
     def self.build(block_id:, &fetch_blocks)
       blocks = fetch_blocks.call(block_id)
+      has_more = blocks["has_more"]
+      next_cursor = blocks["next_cursor"]
+
+      while has_more
+        paginated_blocks = fetch_blocks.call(block_id, next_cursor)
+        blocks["results"].concat(paginated_blocks["results"])
+
+        has_more = paginated_blocks["has_more"]
+        next_cursor = paginated_blocks["next_cursor"]
+      end
+
       blocks.results.map do |block|
         children = if permitted_children?(block: block)
                      build(block_id: block.id, &fetch_blocks)

--- a/lib/notion_to_md/converter.rb
+++ b/lib/notion_to_md/converter.rb
@@ -51,13 +51,17 @@ module NotionToMd
     end
 
     def build_blocks(block_id:)
-      Blocks.build(block_id: block_id) do |nested_block_id|
-        fetch_blocks(block_id: nested_block_id)
+      Blocks.build(block_id: block_id) do |nested_block_id, start_cursor|
+        fetch_blocks(block_id: nested_block_id, start_cursor: start_cursor)
       end
     end
 
-    def fetch_blocks(block_id:)
-      @notion.block_children(block_id: block_id)
+    def fetch_blocks(block_id:, start_cursor: nil)
+      if start_cursor.present?
+        @notion.block_children(block_id: block_id, start_cursor: start_cursor)
+      else
+        @notion.block_children(block_id: block_id)
+      end
     end
   end
 end


### PR DESCRIPTION
This introduces support for paginated Block responses
It should fix the problem of partially imported pages

By default the gem only fetches the first **100 blocks** of a page 