### PR TITLE
Change toggle method to add the markdown=1 attribute

### DIFF
--- a/lib/notion_to_md/blocks/types.rb
+++ b/lib/notion_to_md/blocks/types.rb
@@ -116,7 +116,7 @@ module NotionToMd
 
         def toggle(block)
           result = <<-TEXT
-<details>
+<details markdown="1">
 <summary>#{block.block.toggle["rich_text"].map { |text| Text.send(text[:type], text) }.join}</summary>
 
 #{block.children.map(&:to_md).join("\n")}


### PR DESCRIPTION
As discussed, fix for MD rendering in Kitt.